### PR TITLE
add example how to integrate it into a gradle build

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -107,9 +107,33 @@ For Gradle, use the following dependency:
 testImplementation 'io.github.wimdeblauwe:testcontainers-cypress:${tc-cypress.version}'
 ----
 
-Add `src/test/e2e` as a test resource directory:
+Add `src/test/e2e` as a test resource directory. 
+As Gradle organizes files in the `build` directory differently you need to add one more task to copy the files into the directory expected the container.
 
-_TODO add instructions on how to do this in Gradle (PR welcome)._
+[source, groovy]
+----
+sourceSets.test.resources.srcDirs += ['src/test/e2e']
+
+task copyE2E(type: Copy) {
+    into 'build/resources/test/e2e'
+    exclude 'node_modules'
+    from 'src/test/e2e'
+}
+
+processTestResources.dependsOn copyE2E
+----
+
+The default `GatherTestResultsStrategy` assumes a Maven project and therefore you need to create a custom strategy that fits the Gradle layout.
+
+[source, java]
+----
+MochawesomeGatherTestResultsStrategy gradleTestResultStrategy = new MochawesomeGatherTestResultsStrategy(
+    FileSystems.getDefault().getPath("build", "resources", "test", "e2e", "cypress", "reports", "mochawesome"));
+    
+new CypressContainer()
+     .withGatherTestResultsStrategy(gradleTestResultStrategy)
+----
+
 
 === Usage with a @SpringBootTest
 


### PR DESCRIPTION
Finally I managed to get it up and running using gradle. The main obstacle is the different layout in build folder which results in the cypress files not being in `e2e` folder (as the default expects). 
The second thing which was not so obvious is, that the default `MochawesomeGatherTestResultsStrategy` assumes/uses a maven folder layout which (of course) does not work.